### PR TITLE
feat: add collect

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ pip install superstream
 | filter              | filter        |                                                                                          |
 | map                 | map           |                                                                                          |
 | flatMap             | flat_map      |                                                                                          |
-| collect             | collect       |                                                                                          |
 | collect(groupingBy) | group_by      |                                                                                          |
 | collect(toList)     | to_list       |                                                                                          |
 | collect(toSet)      | to_set        |                                                                                          |

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ pip install superstream
 | filter              | filter        |                                                                                          |
 | map                 | map           |                                                                                          |
 | flatMap             | flat_map      |                                                                                          |
+| collect             | collect       |                                                                                          |
 | collect(groupingBy) | group_by      |                                                                                          |
 | collect(toList)     | to_list       |                                                                                          |
 | collect(toSet)      | to_set        |                                                                                          |

--- a/src/superstream/stream.py
+++ b/src/superstream/stream.py
@@ -1,6 +1,7 @@
 from functools import reduce
 from typing import TypeVar, Callable, List, Set, Generic, Dict, Iterable, Optional, Any
-from itertools import islice, chain
+from itertools import islice, chain, count
+from collections import deque
 
 T = TypeVar('T')
 R = TypeVar('R')
@@ -39,7 +40,9 @@ class Stream(Generic[T]):
         return Stream(sorted(self._stream, key=key, reverse=reverse))
 
     def count(self) -> int:
-        return len(list(self._stream))
+        cnt = count()
+        deque(zip(self._stream, cnt), maxlen=0)
+        return next(cnt)
 
     def sum(self) -> 'T':
         return sum(self._stream)

--- a/src/superstream/stream.py
+++ b/src/superstream/stream.py
@@ -115,3 +115,6 @@ class Stream(Generic[T]):
 
     def to_map(self, k: Callable[[T], K], v: Callable[[T], U]) -> Dict[K, U]:
         return {k(i): v(i) for i in self._stream}
+
+    def collect(self, func: Callable[[Iterable[T]], R]) -> R:
+        return func(self._stream)

--- a/src/superstream/stream.py
+++ b/src/superstream/stream.py
@@ -118,6 +118,3 @@ class Stream(Generic[T]):
 
     def to_map(self, k: Callable[[T], K], v: Callable[[T], U]) -> Dict[K, U]:
         return {k(i): v(i) for i in self._stream}
-
-    def collect(self, func: Callable[[Iterable[T]], R]) -> R:
-        return func(self._stream)


### PR DESCRIPTION
添加 collect 方法，对应 Java Stream 的 collect 方法。
对所有可作用于 iterable 的 func，可以直接使用 collect(func)，而不打断流式操作。如：
.collect(tuple)
.collect(collections.deque)
.collect(collections.Counter)
.collect(statistics.median)