### PR TITLE
refactor: change key parameter of max and min from lambda x: x back to None

### DIFF
--- a/src/superstream/stream.py
+++ b/src/superstream/stream.py
@@ -75,19 +75,23 @@ class Stream(Generic[T]):
     def skip(self, n: int) -> 'Stream[T]':
         return Stream(islice(self._stream, n, None))
 
-    def min(self, key: Callable[[T], Any] = lambda x: x, default: T = None) -> Optional[T]:
+    def min(self, key: Callable[[T], Any] = None, default: T = None) -> Optional[T]:
         """
         :param default: use default value when stream is empty
         :param key: at lease supported __lt__ method
         """
-        return min(self._stream, key=key, default=default)
+        if key is not None:
+            return min(self._stream, key=key, default=default)
+        return min(self._stream, default=default)
 
-    def max(self, key: Callable[[T], Any] = lambda x: x, default: T = None) -> Optional[T]:
+    def max(self, key: Callable[[T], Any] = None, default: T = None) -> Optional[T]:
         """
         :param default: use default value when stream is empty
         :param key: at lease supported __lt__ method
         """
-        return max(self._stream, key=key, default=default)
+        if key is not None:
+            return max(self._stream, key=key, default=default)
+        return max(self._stream, default=default)
 
     def find_first(self) -> Optional[T]:
         try:


### PR DESCRIPTION
看到 "fix: fix max and min function behaving differently than expected" 这个 commit 了。
应该是为解决 stream 为空时报 ValueError 错误的问题。
简单地把 `return min(self._stream)` 改为 `return min(self._stream, default=default)` 可以解决的。
不用为此引入 identity 函数。
用 identity 时，理论上所有元素都要先 identity 一下，会不会有性能损失？
当然，实际上可能没有或者很小。

另外，「在 3.8 版更改: key 可以为 None。」后，
如果不考虑对 Python 3.7 以下版本兼容性的话，
采用你最新的代码，但把 key 设为 None就可以了。