### PR TITLE
feat: add start parameter for sum method

### DIFF
--- a/src/superstream/stream.py
+++ b/src/superstream/stream.py
@@ -48,8 +48,8 @@ class Stream(Generic[T]):
         deque(zip(self._stream, cnt), maxlen=0)
         return next(cnt)
 
-    def sum(self) -> 'T':
-        return sum(self._stream)
+    def sum(self, start: T = 0) -> T:
+        return sum(self._stream, start)
 
     def group_by(self, classifier: Callable[[T], K]) -> Dict[K, List[T]]:
         groups = {}

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -49,6 +49,10 @@ class TestStream:
         b = Stream(a).sum()
         assert b == 6
 
+        a = [[1], [2, 3], [4]]
+        b = Stream(a).sum(start = [0])
+        assert b == [0, 1, 2, 3, 4]
+
     def test_group_by(self):
         a = [{'p': '1', 'name': 'foo'}, {'p': '2', 'name': 'bar'}, {'p': '2', 'name': 'bar'}]
         b = Stream(a).group_by(lambda x: x['p'])


### PR DESCRIPTION
为 sum 方法添加 start 参数，与 python 内置 sum 函数一致。
因为内置 sum 函数的 start 参数默认为 0，如果不添加 start 参数，Stream.sum 只能对数字类型 iterable 求和。
而通过指定 start 参数，Stream.sum 就可以和内置 sum 函数一样，支持所有具有加法操作的类型，如实现了加法的自定义类型。
除了数字求和，sum的一个常见用法的例子就是列表的合并：
``` python
a = [[1], [2, 3], [4]]
b = Stream(a).sum(start = [0])
assert b == [0, 1, 2, 3, 4]
```
