### PR TITLE
fix: rename starmap to star_map, to keep the naming style consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pip install superstream
 | ------------------- | ------------- | ---------------------------------------------------------------------------------------- |
 | filter              | filter        |                                                                                          |
 | map                 | map           |                                                                                          |
-| -                   | starmap       | map 的 \* 参数解包版本                                                                   |
+| -                   | star_map      | map 的 \* 参数解包版本                                                                   |
 | flatMap             | flat_map      |                                                                                          |
 | collect             | collect       |                                                                                          |
 | -                   | collects      | collect 对应的中间操作，collects(collector) 相当于 Java 中的 collect(collector).stream() |

--- a/src/superstream/stream.py
+++ b/src/superstream/stream.py
@@ -24,7 +24,7 @@ class Stream(Generic[T]):
     def map(self, func: Callable[[T], R]) -> 'Stream[R]':
         return Stream(map(func, self._stream))
 
-    def starmap(self, func: Callable[..., R]) -> 'Stream[R]':
+    def star_map(self, func: Callable[..., R]) -> 'Stream[R]':
         return Stream(starmap(func, self._stream))
 
     def flat_map(self, func: Callable[[T], 'Stream[R]']) -> 'Stream[R]':

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -10,9 +10,9 @@ class TestStream:
         b = Stream(a).map(lambda x: x * 2).to_list()
         assert b == [2, 4, 6]
 
-    def test_starmap(self):
+    def test_star_map(self):
         a = [(2,5), (3,2), (10,3)]
-        b = Stream(a).starmap(pow).to_list()
+        b = Stream(a).star_map(pow).to_list()
         assert b == [32, 9, 1000]
 
     def test_flat_map(self):


### PR DESCRIPTION
先把 starmap 改成 star_map 吧，和其他方法的命名风格统一起来。
早点修改，对其他使用者影响小一点。