### PR TITLE
refactor: speed up for_each, by using deque to avoid explicit for loop

### DIFF
--- a/src/superstream/stream.py
+++ b/src/superstream/stream.py
@@ -34,8 +34,7 @@ class Stream(Generic[T]):
         return Stream(filter(func, self._stream))
 
     def for_each(self, func: Callable[[T], None]) -> None:
-        for i in self._stream:
-            func(i)
+        deque(map(func, self._stream), maxlen=0)
 
     def distinct(self):
         return Stream(list(dict.fromkeys(self._stream)))


### PR DESCRIPTION
通过 deque 和 map 操作将 for_each 中 func 的循环放到 C 语言中， 避免 python 的显式 for 循环。
itertools recipes 中用 maxlen=0 的 deque 实现 consume 函数，用于快速消耗 iterator 。
在其他地方也见到 deque 的类似用途，例如我们对 count 的实现。
我已经测试过，这个实现比显式 for 循环快一些。